### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Installation
 
 ```bash
-$ npm i @scalio-oss/nest-couchbase couchbase
+$ npm i @scalio-oss/nest-couchbase couchbase@2.6.5
 ```
 
 ## Usage
@@ -93,6 +93,12 @@ export class CatsService {
   findOne(id: string): Promise<Cat> {
     return this.catsRepository.get(id);
   }
+  
+  upsert(key: string, cat: Cat): Promise<Cat> {
+    return (this.repositoryCacheLike as any).upsert(key, cat)
+  }
+  
+  
 }
 ```
 


### PR DESCRIPTION
* The default Couchbase from npm is 3.0.1, which breaks the functionality.
Need to install explicitly version 2.6.5.

*Calling upsert method is a bit tricky since casting to 'any' is needed - added an example.